### PR TITLE
add sort order option to projects, default to adding at the start

### DIFF
--- a/src/pages/projects/frances-ha.md
+++ b/src/pages/projects/frances-ha.md
@@ -1,19 +1,20 @@
 ---
 title: Frances Ha
+order: 5
 templateKey: project-page
-seoKeywords: 'portrait, illustration, portrait illustration, matt peet illustration'
+seoKeywords: "portrait, illustration, portrait illustration, matt peet illustration"
 thumbnail: /img/fh-thumbnail.jpg
 thumbnailTitle: Poster design
 socialImage: /img/fh-thumbnail.jpg
 images:
-  - altText: 'Portrait illustration, Greta Gerwig as Frances Ha'
+  - altText: "Portrait illustration, Greta Gerwig as Frances Ha"
     description: |-
       Greta Gerwig as Frances Ha
 
       2021
     image: /img/fh-poster.jpg
     imageTitle: Portrait illustration
-  - altText: 'Poster design, Greta Gerwig as Frances Ha'
+  - altText: "Poster design, Greta Gerwig as Frances Ha"
     description: |-
       Greta Gerwig as Frances Ha
 
@@ -21,4 +22,3 @@ images:
     image: /img/fh-poster2.jpg
     imageTitle: Poster design
 ---
-

--- a/src/pages/projects/ian-rankin.md
+++ b/src/pages/projects/ian-rankin.md
@@ -1,5 +1,6 @@
 ---
 title: Ian Rankin
+order: 0
 templateKey: project-page
 seoKeywords: portrait, illustration, portrait illustration, matt peet illustration
 thumbnail: /img/23.03.21.jpg

--- a/src/pages/projects/irvine-welsh.md
+++ b/src/pages/projects/irvine-welsh.md
@@ -1,5 +1,6 @@
 ---
 title: 1. Irvine Welsh
+order: 0
 templateKey: project-page
 seoKeywords: portrait, illustration, portrait illustration, matt peet illustration
 thumbnail: /img/22.03.21.jpg

--- a/src/pages/projects/john-jung-for-pluralsight-com.md
+++ b/src/pages/projects/john-jung-for-pluralsight-com.md
@@ -1,12 +1,13 @@
 ---
 title: John Jung for Pluralsight.com
+order: 0
 templateKey: project-page
-seoKeywords: 'portrait, illustration, portrait illustration, matt peet illustration'
+seoKeywords: "portrait, illustration, portrait illustration, matt peet illustration"
 thumbnail: /img/pluralsight-thumbnail1.jpg
 thumbnailTitle: Portrait illustration for Pluralsight.com
 socialImage: /img/pluralsight-johnjung-1200x636px.jpg
 images:
-  - altText: 'Portrait illustration, John Jung for Pluralsight.com'
+  - altText: "Portrait illustration, John Jung for Pluralsight.com"
     description: >-
       Director of Engineering at API workflow infrastructure company Nylas
 
@@ -24,4 +25,3 @@ images:
     image: /img/pluralsight-johnjung-screenshot.png
     imageTitle: John Jung screenshot
 ---
-

--- a/src/pages/projects/kim-burgaard-for-pluralsight-com.md
+++ b/src/pages/projects/kim-burgaard-for-pluralsight-com.md
@@ -1,12 +1,13 @@
 ---
 title: Kim Burgaard for Pluralsight.com
+order: 0
 templateKey: project-page
-seoKeywords: 'portrait, illustration, portrait illustration, matt peet illustration'
+seoKeywords: "portrait, illustration, portrait illustration, matt peet illustration"
 thumbnail: /img/pluralsight-kimburgaard-1200x636px.jpg
 thumbnailTitle: Portrait illustration for Pluralsight.com
 socialImage: /img/pluralsight-kimburgaard-1200x636px.jpg
 images:
-  - altText: 'Portrait illustration, Kim Burgaard for Pluralsight.com'
+  - altText: "Portrait illustration, Kim Burgaard for Pluralsight.com"
     description: >-
       Director of Engineering at Fernish
 
@@ -16,7 +17,7 @@ images:
       2021**
     image: /img/pluralsight-kimburgaard-1200x636px.jpg
     imageTitle: Kim Burgaard
-  - altText: 'Screenshot, Pluralsight.com'
+  - altText: "Screenshot, Pluralsight.com"
     description: >-
       **For**
       [**Pluralsight.com**](https://www.pluralsight.com/blog/teams/process-of-change-kim-burgaard)**,
@@ -24,4 +25,3 @@ images:
     image: /img/pluralsight-kimburgaard-screenshot.png
     imageTitle: Kim Burgaard
 ---
-

--- a/src/pages/projects/kim-burgaard-for-pluralsight-com.md
+++ b/src/pages/projects/kim-burgaard-for-pluralsight-com.md
@@ -1,6 +1,6 @@
 ---
 title: Kim Burgaard for Pluralsight.com
-order: 0
+order: 5
 templateKey: project-page
 seoKeywords: "portrait, illustration, portrait illustration, matt peet illustration"
 thumbnail: /img/pluralsight-kimburgaard-1200x636px.jpg

--- a/src/pages/projects/yaphi-berhanu-for-pluralsight-com.md
+++ b/src/pages/projects/yaphi-berhanu-for-pluralsight-com.md
@@ -1,12 +1,13 @@
 ---
 title: Yaphi Berhanu for Pluralsight.com
+order: 2
 templateKey: project-page
-seoKeywords: 'portrait, illustration, portrait illustration, matt peet illustration'
+seoKeywords: "portrait, illustration, portrait illustration, matt peet illustration"
 thumbnail: /img/pluralsight-yaphiberhanu-870x570px.jpg
 thumbnailTitle: Portrait illustration for Pluralsight.com
 socialImage: /img/pluralsight-yaphiberhanu-870x570px.jpg
 images:
-  - altText: 'Portrait illustration, Yaphi Berhanu for Pluralsight.com'
+  - altText: "Portrait illustration, Yaphi Berhanu for Pluralsight.com"
     description: >-
       Senior Software Engineer at Squarespace
 
@@ -16,7 +17,7 @@ images:
       2021**
     image: /img/pluralsight-yaphiberhanu-1200x636px.jpg
     imageTitle: Yaphi Berhanu
-  - altText: 'Screenshot, Pluralsight.com'
+  - altText: "Screenshot, Pluralsight.com"
     description: >-
       **For**
       [**Pluralsight.com**](https://www.pluralsight.com/blog/teams/squarespace-yaphi-berhanu-leaders-words)**,
@@ -24,4 +25,3 @@ images:
     image: /img/pluralsight-yaphiberhanu-screenshot.png
     imageTitle: Yaphi Berhanu
 ---
-

--- a/src/pages/projects/young-fathers.md
+++ b/src/pages/projects/young-fathers.md
@@ -1,5 +1,6 @@
 ---
 title: Young Fathers
+order: 1
 templateKey: project-page
 seoKeywords: portrait, illustration, portrait illustration, matt peet illustration
 thumbnail: /img/yf-24.03.21iii.jpg

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -68,10 +68,12 @@ export const pageQuery = graphql`
     }
     projects: allMarkdownRemark(
       filter: { frontmatter: { templateKey: { eq: "project-page" } } }
+      sort: { order: ASC, fields: [frontmatter___order] }
     ) {
       nodes {
         frontmatter {
           title
+          order
           thumbnail {
             childImageSharp {
               gatsbyImageData(placeholder: DOMINANT_COLOR)

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -99,6 +99,7 @@ collections:
     create: true
     fields:
       - { title: 'Title', name: 'title', widget: 'string' }
+      - { title: 'Display order', name: 'order', widget: 'number', value_type: 'int', default: 0 }
       - {
           label: 'Template Key',
           name: 'templateKey',


### PR DESCRIPTION
Add a new CMS field to switch up the sort order on the index page. Leaving the field at its default value places projects to the start of the list.