### PR TITLE
fix mismatched breakpoint

### DIFF
--- a/src/components/global.module.css
+++ b/src/components/global.module.css
@@ -30,7 +30,7 @@ a:hover {
   padding: 25px;
 }
 
-@media (min-width: 820px) and (orientation: landscape) {
+@media (min-width: 768px) and (orientation: landscape) {
   .containerGrid {
     grid-template-columns: 30% 70%;
   }


### PR DESCRIPTION
This solves the issue we spotted where for a tiny portion of resizing the window, the index grid moved below but the nav didn't collapse to the hamburger